### PR TITLE
NestedViewerExtension updates.

### DIFF
--- a/public/extensions/NestedViewerExtension/README.md
+++ b/public/extensions/NestedViewerExtension/README.md
@@ -12,6 +12,7 @@ Forge Viewer extension showing viewables related to the currently loaded model i
 
 The extension accepts an optional _options_ object with the following properties:
 - `filter` - array of allowed viewable "roles" ("2d", "3d", or both), by default: `["2d", "3d"]`
+- `crossSelection` - boolean flag for cross-selecting elements after they're selected in the main or the nested viewer, `false` by default
 
 ## How it works
 

--- a/public/extensions/NestedViewerExtension/README.md
+++ b/public/extensions/NestedViewerExtension/README.md
@@ -1,0 +1,17 @@
+# NestedViewerExtension
+
+Forge Viewer extension showing viewables related to the currently loaded model in another instance of the viewer.
+
+## Usage
+
+- Load the extension in the viewer
+- Click the <img src="https://img.icons8.com/color/64/000000/picture-in-picture.png" width=16> icon in the toolbar
+- New dialog will open, showing a dropdown list of all viewables available for the currently loaded model
+
+## How it works
+
+The extension uses another instance of [GuiViewer3D](https://forge.autodesk.com/en/docs/viewer/v7/reference/Viewing/GuiViewer3D/)
+and places it in a custom [DockingPanel](https://forge.autodesk.com/en/docs/viewer/v7/reference/UI/DockingPanel/).
+Whenever the "main" viewer loads a different model (observed via the `Autodesk.Viewing.MODEL_ROOT_LOADED_EVENT` event),
+the extension collects all viewables available in this model (using `doc.getRoot().search({ type: 'geometry' })`),
+and makes them available in the docking panel's dropdown.

--- a/public/extensions/NestedViewerExtension/README.md
+++ b/public/extensions/NestedViewerExtension/README.md
@@ -8,6 +8,11 @@ Forge Viewer extension showing viewables related to the currently loaded model i
 - Click the <img src="https://img.icons8.com/color/64/000000/picture-in-picture.png" width=16> icon in the toolbar
 - New dialog will open, showing a dropdown list of all viewables available for the currently loaded model
 
+## Configuration
+
+The extension accepts an optional _options_ object with the following properties:
+- `filter` - array of allowed viewable "roles" ("2d", "3d", or both), by default: `["2d", "3d"]`
+
 ## How it works
 
 The extension uses another instance of [GuiViewer3D](https://forge.autodesk.com/en/docs/viewer/v7/reference/Viewing/GuiViewer3D/)

--- a/public/extensions/NestedViewerExtension/config.json
+++ b/public/extensions/NestedViewerExtension/config.json
@@ -2,7 +2,9 @@
     "name": "NestedViewerExtension",
     "displayname": "Viewer in Viewer",
     "description": "Nested viewer where viewables related to the currently loaded model can be viewed.",
-    "options": {},
+    "options": {
+        "filter": ["2d", "3d"]
+    },
     "viewerversion": "7.*",
     "loadonstartup": "false",
     "filestoload": {

--- a/public/extensions/NestedViewerExtension/config.json
+++ b/public/extensions/NestedViewerExtension/config.json
@@ -3,7 +3,8 @@
     "displayname": "Viewer in Viewer",
     "description": "Nested viewer where viewables related to the currently loaded model can be viewed.",
     "options": {
-        "filter": ["2d", "3d"]
+        "filter": ["2d", "3d"],
+        "crossSelection": true
     },
     "viewerversion": "7.*",
     "loadonstartup": "false",

--- a/public/extensions/NestedViewerExtension/config.json
+++ b/public/extensions/NestedViewerExtension/config.json
@@ -1,7 +1,7 @@
 {
     "name": "NestedViewerExtension",
     "displayname": "Viewer in Viewer",
-    "description": "Extension providing a panel with another viewer.",
+    "description": "Nested viewer where viewables related to the currently loaded model can be viewed.",
     "options": {},
     "viewerversion": "7.*",
     "loadonstartup": "false",
@@ -9,5 +9,6 @@
         "cssfiles": ["main.css"],
         "jsfiles": ["main.js"]
     },
-    "includeinlist": "true"
+    "includeinlist": "true",
+    "bloglink": "https://github.com/libvarun/forge-extensions/tree/master/public/extensions/NestedViewerExtension/README.md"
 }

--- a/public/extensions/NestedViewerExtension/contents/main.css
+++ b/public/extensions/NestedViewerExtension/contents/main.css
@@ -3,4 +3,9 @@
     background-size: 24px;
     background-repeat: no-repeat;
     background-position: center;
+    filter: grayscale(100%);
+}
+
+#nestedViewerExtensionButton.active {
+    filter: none;
 }

--- a/public/extensions/NestedViewerExtension/contents/main.js
+++ b/public/extensions/NestedViewerExtension/contents/main.js
@@ -103,7 +103,7 @@ class NestedViewerPanel extends Autodesk.Viewing.UI.DockingPanel {
         this.container.style.width = '500px';
         this.container.style.height = '400px';
 
-        this.title = this.createTitleBar(this.titleLabel || this.container.id); // height: 50px
+        this.title = this.createTitleBar(this.titleLabel || this.container.id);
         this.container.appendChild(this.title);
 
         this._container = document.createElement('div');
@@ -111,7 +111,7 @@ class NestedViewerPanel extends Autodesk.Viewing.UI.DockingPanel {
         this._container.style.left = '0';
         this._container.style.top = '50px';
         this._container.style.width = '100%';
-        this._container.style.height = '350px';
+        this._container.style.height = '330px'; // 400px - 50px (title bar) - 20px (footer)
         this.container.appendChild(this._container);
 
         this._dropdown = document.createElement('select');
@@ -124,6 +124,14 @@ class NestedViewerPanel extends Autodesk.Viewing.UI.DockingPanel {
         this._container.appendChild(this._dropdown);
 
         this.initializeMoveHandlers(this.container);
+        this._footer = this.createFooter();
+        this.footerInstance.resizeCallback = (width, height) => {
+            this._container.style.height = `${height - 50 /* title bar */ - 20 /* footer */}px`;
+            if (this._viewer) {
+                this._viewer.resize();
+            }
+        };
+        this.container.appendChild(this._footer);
     }
 
     setVisible(show) {

--- a/public/extensions/NestedViewerExtension/contents/main.js
+++ b/public/extensions/NestedViewerExtension/contents/main.js
@@ -1,6 +1,8 @@
 class NestedViewerExtension extends Autodesk.Viewing.Extension {
     constructor(viewer, options) {
         super(viewer, options);
+        options = options || {};
+        this._filter = options.filter || ['2d', '3d'];
         this._group = null;
         this._button = null;
         this._panel = null;
@@ -44,7 +46,7 @@ class NestedViewerExtension extends Autodesk.Viewing.Extension {
         this._button = new Autodesk.Viewing.UI.Button('nestedViewerExtensionButton');
         this._button.onClick = (ev) => {
             if (!this._panel) {
-                this._panel = new NestedViewerPanel(this.viewer);
+                this._panel = new NestedViewerPanel(this.viewer, this._filter);
                 this._panel.urn = this.viewer.model.getData().urn;
             }
             if (this._panel.isVisible()) {
@@ -62,9 +64,10 @@ class NestedViewerExtension extends Autodesk.Viewing.Extension {
 }
 
 class NestedViewerPanel extends Autodesk.Viewing.UI.DockingPanel {
-    constructor(viewer) {
+    constructor(viewer, filter) {
         super(viewer.container, 'nested-viewer-panel', 'Nested Viewer');
         this._urn = '';
+        this._filter = filter;
     }
 
     get urn() {
@@ -119,7 +122,8 @@ class NestedViewerPanel extends Autodesk.Viewing.UI.DockingPanel {
     _updateDropdown() {
         const onDocumentLoadSuccess = (doc) => {
             this._manifest = doc;
-            const geometries = doc.getRoot().search({ type: 'geometry' });
+            const filterGeom = (geom) => this._filter.indexOf(geom.data.role) !== -1;
+            const geometries = doc.getRoot().search({ type: 'geometry' }).filter(filterGeom);
             this._dropdown.innerHTML = geometries.map(function (geom) {
                 return `<option value="${geom.guid()}">${geom.name()}</option>`;
             }).join('\n');

--- a/public/extensions/NestedViewerExtension/contents/main.js
+++ b/public/extensions/NestedViewerExtension/contents/main.js
@@ -47,7 +47,13 @@ class NestedViewerExtension extends Autodesk.Viewing.Extension {
                 this._panel = new NestedViewerPanel(this.viewer);
                 this._panel.urn = this.viewer.model.getData().urn;
             }
-            this._panel.setVisible(!this._panel.isVisible());
+            if (this._panel.isVisible()) {
+                this._panel.setVisible(false);
+                this._button.removeClass('active');
+            } else {
+                this._panel.setVisible(true);
+                this._button.addClass('active');
+            }
         };
         this._button.setToolTip('Nested Viewer');
         this._button.addClass('nestedViewerExtensionIcon');


### PR DESCRIPTION
Addressing suggestions from https://github.com/libvarun/forge-extensions/issues/14, this pull request:

- adds a README explaining what the extension does, how it can be used, and how it works
- provides a link to the README in the config JSON
- makes the toolbar button "on/off", with a visual feedback indicating whether the extension is active
- adds a config option to filter only 2d or 3d viewables to be listed in the nested viewer dropdown
- adds a config option to cross-select objects when they're selected in the main or the nested viewer
- makes the nested viewer panel resizable