### PR TITLE
Adjust on readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This sample is based on the [Learn Forge](http://learnforge.autodesk.io) tutoria
 
 ## Thumbnail
 
-![thumbnail](/thumbnail.png)
+![thumbnail](/thumbnail.PNG)
 
 ## Live Demo
 

--- a/README.md
+++ b/README.md
@@ -5,33 +5,47 @@
 ![Platforms](https://img.shields.io/badge/platform-windows%20%7C%20osx%20%7C%20linux-lightgray.svg)
 [![License](http://img.shields.io/:license-mit-blue.svg)](http://opensource.org/licenses/MIT)
 
-[![oAuth2](https://img.shields.io/badge/oAuth2-v1-green.svg)](http://developer.autodesk.com/)
-[![Data-Management](https://img.shields.io/badge/Data%20Management-v1-green.svg)](http://developer.autodesk.com/)
-[![OSS](https://img.shields.io/badge/OSS-v2-green.svg)](http://developer.autodesk.com/)
-[![Model-Derivative](https://img.shields.io/badge/Model%20Derivative-v2-green.svg)](http://developer.autodesk.com/)
+[![oAuth2](https://img.shields.io/badge/oAuth2-v1-green.svg)](http://forge.autodesk.com/)
+[![Data-Management](https://img.shields.io/badge/Data%20Management-v1-green.svg)](http://forge.autodesk.com/)
+[![Model-Derivative](https://img.shields.io/badge/Model%20Derivative-v2-green.svg)](http://forge.autodesk.com/)
+[![Viewer](https://img.shields.io/badge/Viewer-v7-green.svg)](http://forge.autodesk.com/)
 
-## Live Demo: https://forge-extensions.herokuapp.com/
+[![Level](https://img.shields.io/badge/Level-Basic-blue.svg)](http://forge.autodesk.com/)
 
 # Description
 
-This sample is part of the [Learn Forge](http://learnforge.autodesk.io) tutorials.
-Autodesk Forge Viewer Extensions with loose coupling, so that it's easy to plug and play in other projects.
-This repo is built on top of [Learn Forge Github repo](https://github.com/Autodesk-Forge/learn.forge.viewmodels/tree/nodejs)
+This sample is a collection of extensions ready to be reused. Just add reference to the required files, load and use. Check each extension documentation for details.
 
-### Extensions List:
-1) Transform
+1. [Camera Rotation](public/extensions/CameraRotation)
+2. [Icon Markup](public/extensions/IconMarkupExtension)
+3. [Nested Viewer](public/extensions/NestedViewerExtension)
+4. [Transform](public/extensions/TransformationExtension)
+
+Extensions were created using a [Basic Skeleton](public/extensions/BasicSkeleton).
+
+This sample is based on the [Learn Forge](http://learnforge.autodesk.io) tutorials in the section *View modelss*.
+
+## Thumbnail
+
+![thumbnail](/thumbnail.png)
+
+## Live Demo
+
+Extensions are dynamically loaded and unloaded for testing on the live version.
+
+[forge-extensions.autodesk.io](https://forge-extensions.autodesk.io)
 
 # Setup
 
-To use this sample, you will need Autodesk developer credentials. Visit the [Forge Developer Portal](https://developer.autodesk.com), sign up for an account, then [create an app](https://developer.autodesk.com/myapps/create). For this new app, use **http://localhost:3000/api/forge/callback/oauth** as the Callback URL, although it is not used on a 2-legged flow. Finally, take note of the **Client ID** and **Client Secret**.
+To use this sample, you will need Autodesk developer credentials. Visit the [Forge Developer Portal](https://developer.autodesk.com), sign up for an account, then [create an app](https://developer.autodesk.com/myapps/create). For this new app, use `http://localhost:3000/api/forge/callback/oauth` as the Callback URL, although it is not used on a 2-legged flow. Finally, take note of the **Client ID** and **Client Secret**.
 
-### Run locally
+## Run locally
 
 Install [NodeJS](https://nodejs.org).
 
 Clone this project or download it. It's recommended to install [GitHub Desktop](https://desktop.github.com/). To clone it via command line, use the following (**Terminal** on MacOSX/Linux, **Git Shell** on Windows):
 
-    git clone https://github.com/libvarun/forge-extensions.git
+    git clone https://github.com/autodesk-forge/forge-extensions.git
 
 To run it, install the required packages, set the enviroment variables with your client ID & Secret and finally start it. Via command line, navigate to the folder where this repository was cloned to and use the following commands:
 
@@ -51,7 +65,7 @@ Windows (use **Node.js command line** from the Start menu)
 
 Open the browser: [http://localhost:3000](http://localhost:3000).
 
-### Steps to plug in new extension:
+# Steps to plug in new extension
 
 1) Create folder in public/extensions with same name as extension name.
 Structure of the extension folder is as shown below:
@@ -65,7 +79,7 @@ ExtensionName[Folder]
         |     |->assets[folder]
         |->config.json
 </pre>        
-Refer the [BasicSkeleton Extension](https://github.com/libvarun/forge-extensions/tree/master/public/extensions/BasicSkeleton) for boilerplate code.
+Refer the [BasicSkeleton Extension](https://github.com/autodesk-forge/forge-extensions/tree/master/public/extensions/BasicSkeleton) for boilerplate code.
 
 2) Each extension folder should be self-contained code, so that it's easily shareable between projects.
 Extension[Folder]/config.json is meant for keeping the config of an extension and for sharing.
@@ -87,7 +101,7 @@ Extension config schema:
     "includeinlist":"true or false"
 }
 </pre>
-Example: [IconMarkupExtension config.json](https://github.com/libvarun/forge-extensions/blob/master/public/extensions/IconMarkupExtension/config.json)
+Example: [IconMarkupExtension config.json](https://github.com/autodesk-forge/forge-extensions/blob/master/public/extensions/IconMarkupExtension/config.json)
 
 > Note: If your extension relies on event Autodesk.Viewing.OBJECT_TREE_CREATED_EVENT to load, in load function check if the data is already loaded, if not only then add the event listener, below code shows the structure.
 <pre>
@@ -110,20 +124,20 @@ class MyExtension extends Autodesk.Viewing.Extension {
     ...
 }
 </pre>
-Example: [IconMarkupExtension load function](https://github.com/libvarun/forge-extensions/blob/master/public/extensions/IconMarkupExtension/contents/main.js#L26)
+Example: [IconMarkupExtension load function](https://github.com/autodesk-forge/forge-extensions/blob/master/public/extensions/IconMarkupExtension/contents/main.js#L26)
 
-### Understanding extensionloader and using it in forge app:
+# Understanding extensionloader and using it in forge app
 
 The way loose coupling between extensions and forge app is achived is with custom event, if you want to use extensionloader in your forge app, follow the three steps:
 
-1) Copy paste the [extensions](https://github.com/libvarun/forge-extensions/tree/master/public/extensions) in public folder of your app or in the folder where the index file resides. 
+1) Copy paste the [extensions](https://github.com/autodesk-forge/forge-extensions/tree/master/public/extensions) in public folder of your app or in the folder where the index file resides. 
 
 2) Include below script in index.html file
 <pre>
 <script src="/extensions/extensionloader.js"></script>
 </pre>
 
-3) Here's the linking part between the app and the extensionloader, in viewer [onDocumentLoadSuccess](https://github.com/libvarun/forge-extensions/blob/master/public/js/ForgeViewer.js#L35) function, emit an event to inform the extensionloader that viewer has loaded the model with the below [code](https://github.com/libvarun/forge-extensions/blob/master/public/js/ForgeViewer.js#L39):
+3) Here's the linking part between the app and the extensionloader, in viewer [onDocumentLoadSuccess](https://github.com/autodesk-forge/forge-extensions/blob/master/public/js/ForgeViewer.js#L35) function, emit an event to inform the extensionloader that viewer has loaded the model with the below [code](https://github.com/autodesk-forge/forge-extensions/blob/master/public/js/ForgeViewer.js#L39):
 <pre>
 var ViewerInstance = new CustomEvent("viewerinstance", {detail: {viewer: viewer}});      
 document.dispatchEvent(ViewerInstance);
@@ -180,8 +194,8 @@ Please see the [LICENSE](LICENSE) file for full details.
 
 ## Written by
 
-Varun Patil [@VarunPatil578](https://twitter.com/VarunPatil578), [Forge Partner Development](http://forge.autodesk.com)
+The [Forge Advocates](http://forge.autodesk.com) team:
 
-Petr Broz [@ipetrbroz](https://twitter.com/ipetrbroz), [Forge Partner Development](http://forge.autodesk.com)
-
-Augusto Goncalves [@augustomaia](https://twitter.com/augustomaia), [Forge Partner Development](http://forge.autodesk.com)
+* Varun Patil [@VarunPatil578](https://twitter.com/VarunPatil578)
+* Petr Broz [@ipetrbroz](https://twitter.com/ipetrbroz)
+* Augusto Goncalves [@augustomaia](https://twitter.com/augustomaia)

--- a/public/extensions/BasicSkeleton/README.md
+++ b/public/extensions/BasicSkeleton/README.md
@@ -1,4 +1,4 @@
-## Basic Skeleton
+# Basic Skeleton
 
-This extension can be used as boilerplate code for creating a custom extension.
+This basic skeleton extension can be used as boilerplate code for creating a custom extension. Please refer to [this tutorial](https://learnforge.autodesk.io/#/viewer/extensions/skeleton) for additional details.
 

--- a/public/extensions/CameraRotation/README.md
+++ b/public/extensions/CameraRotation/README.md
@@ -1,3 +1,26 @@
-## Camera Rotation
+# Camera Rotation
 
-This extension can be used for model demo purpose, it just rorates the building or the model for look around.
+This extension can be used for model demo purpose, it just rotates the building or the model for look around.
+
+![thumbnail](extension.gif)
+
+## Usage
+
+Click on the toolbar button to start rotating, click again to stop.
+
+## Setup
+
+Include the CSS & JS file on your page. This CDN is compatible with the lastest Viewer version (v7).
+
+```xml
+<link rel="stylesheet" href="http://cdn.jsdelivr.net/gh/autodesk-forge/forge-extensions/public/extensions/camerarotation/contents/main.css">
+<script src="http://cdn.jsdelivr.net/gh/autodesk-forge/forge-extensions/public/extensions/camerarotation/contents/main.js"></script>
+```
+
+After Viewer is ready, preferable inside `onDocumentLoadSuccess`, load the extension
+
+```javascript
+viewer.loadExtension("CameraRotation")
+```
+
+## How it works

--- a/public/extensions/IconMarkupExtension/README.md
+++ b/public/extensions/IconMarkupExtension/README.md
@@ -1,3 +1,56 @@
-## Icon Markup Extension
+# Icon Markup Extension
 
-Detailed technical explaination can be found here: https://forge.autodesk.com/blog/placing-custom-markup-dbid
+Extension showing labels on top of elements, based on their `dbId`.
+
+![thumbnail](extension.gif)
+
+## Setup
+
+Include the CSS & JS file on your page. This CDN is compatible with the lastest Viewer version (v7).
+
+```xml
+<link rel="stylesheet" href="http://cdn.jsdelivr.net/gh/autodesk-forge/forge-extensions/public/extensions/IconMarkupExtension/contents/main.css">
+<script src="http://cdn.jsdelivr.net/gh/autodesk-forge/forge-extensions/public/extensions/IconMarkupExtension/contents/main.js"></script>
+```
+
+The following sample uses [font-awesome](https://fontawesome.com) icons, but any CSS icon library can be used.
+
+```xml
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
+```
+Load the extension passing the `dbId`, `label` and `css` for the label. Toolbar button and onClick event can also be configured. 
+
+```javascript
+viewer.loadExtension('IconMarkupExtension', {
+            button: {
+                icon: 'fa-thermometer-half',
+                tooltip: 'Show Temperature'
+            },
+            icons: [
+                { dbId: 3944,   label: '300&#176;C', css: 'fas fa-thermometer-full' },
+                { dbId: 721,    label: '356&#176;C', css: 'fas fa-thermometer-full' },
+                { dbId: 10312,  label: '450&#176;C', css: 'fas fa-thermometer-empty' },
+                { dbId: 563,                         css: 'fas fa-exclamation-triangle' },
+            ],
+            onClick: (id) => {
+                viewers.select(id);
+                viewers.utilities.fitToView();
+                switch (id){
+                    case 563:
+                        alert('Sensor offline');
+                }
+            }
+        })
+```
+
+## Configuration
+
+The `button` attribute defines the toolbar button. The `icons` contains the labels shwon on the model. Last, `onClick` is triggered when the user clicks on the label. 
+
+## How it works
+
+Labels are positioned over the Viewer canvas and repositioned when the camera changes (e.g. pan, zoom or rotate).
+
+## Futher reading
+
+Detailed technical explaination can be found at [this blog post](https://forge.autodesk.com/blog/placing-custom-markup-dbid). This [live sample](http://forgeplant.herokuapp.com) shows an sample application.

--- a/public/extensions/IconMarkupExtension/config.json
+++ b/public/extensions/IconMarkupExtension/config.json
@@ -4,9 +4,7 @@
     "description": "Markups example, based on options provided in config, info is showed on particular object referring dbid.",
     "options":{
         "icons": [
-            { "dbId": 920,   "label": "300&#176;C", "css": "temperatureHigh fas fa-thermometer-full" },
-            { "dbId": 915,    "label": "356&#176;C", "css": "temperatureBorder temperatureHigh fas fa-thermometer-full" },
-            { "dbId": 1626,  "label": "450&#176;C", "css": "temperatureBorder temperatureOk fas fa-thermometer-empty" }
+            { "dbId": 9256,   "label": "300&#176;C", "css": "fas fa-thermometer-full" }
         ],
         "button": {
             "icon": "fa-thermometer-half",
@@ -19,11 +17,11 @@
         "cssfiles":["main.css"],
         "jsfiles":["main.js"]
     },
-    "bloglink":"https://forge.autodesk.com/blog/placing-custom-markup-dbid",
+    "bloglink":"https://github.com/autodesk-forge/forge-extensions/tree/master/public/extensions/IconMarkupExtension",
     "includeinlist":"true",
     "gif": "extension.gif",
     "externaldependencies":[
-        {"type": "js", "link": "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"}
+        {"type": "css", "link": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css"}
     ]
         
 }

--- a/public/extensions/NestedViewerExtension/README.md
+++ b/public/extensions/NestedViewerExtension/README.md
@@ -2,11 +2,28 @@
 
 Forge Viewer extension showing viewables related to the currently loaded model in another instance of the viewer.
 
+![thumbnail](extension.gif)
+
 ## Usage
 
 - Load the extension in the viewer
 - Click the <img src="https://img.icons8.com/color/64/000000/picture-in-picture.png" width=16> icon in the toolbar
 - New dialog will open, showing a dropdown list of all viewables available for the currently loaded model
+
+## Setup
+
+Include the CSS & JS file on your page. This CDN is compatible with the lastest Viewer version (v7).
+
+```xml
+<link rel="stylesheet" href="http://cdn.jsdelivr.net/gh/autodesk-forge/forge-extensions/public/extensions/NestedViewerExtension/contents/main.css">
+<script src="http://cdn.jsdelivr.net/gh/autodesk-forge/forge-extensions/public/extensions/NestedViewerExtension/contents/main.js"></script>
+```
+
+After Viewer is ready, preferable inside `onDocumentLoadSuccess`, load the extension
+
+```javascript
+viewer.loadExtension("NestedViewerExtension", { filter: ["2d", "3d"], crossSelection: true })
+```
 
 ## Configuration
 

--- a/public/extensions/NestedViewerExtension/config.json
+++ b/public/extensions/NestedViewerExtension/config.json
@@ -14,5 +14,5 @@
     },
     "gif": "extension.gif",
     "includeinlist": "true",
-    "bloglink": "https://github.com/libvarun/forge-extensions/tree/master/public/extensions/NestedViewerExtension/README.md"
+    "bloglink": "https://github.com/autodesk-forge/forge-extensions/tree/master/public/extensions/NestedViewerExtension/README.md"
 }

--- a/public/extensions/TransformationExtension/README.md
+++ b/public/extensions/TransformationExtension/README.md
@@ -1,0 +1,28 @@
+# Transform
+
+Allows moving elements on the model.
+
+![thumbnail](extension.gif)
+
+## Usage
+
+Enable the extension, click on the model element, use the `gizmo` to move the element.
+
+## Setup
+
+Include the CSS & JS file on your page. This CDN is compatible with the lastest Viewer version (v7).
+
+```xml
+<link rel="stylesheet" href="http://cdn.jsdelivr.net/gh/autodesk-forge/forge-extensions/public/extensions/transform/contents/main.css">
+<script src="http://cdn.jsdelivr.net/gh/autodesk-forge/forge-extensions/public/extensions/transform/contents/main.js"></script>
+```
+
+After Viewer is ready, preferable inside `onDocumentLoadSuccess`, load the extension
+
+```javascript
+viewer.loadExtension("TransformationExtension")
+```
+
+## How it works
+
+

--- a/public/extensions/extensionloader.js
+++ b/public/extensions/extensionloader.js
@@ -75,7 +75,7 @@ function init(config){
             let element = Extensions[index];
             let  moredetails = '';
             let gif = '';                
-            if(element.bloglink) moredetails = 'Details:  <a target="_blank" href="'+element.bloglink+'">Blog link</a>';
+            if(element.bloglink) moredetails = '<a target="_blank" href="'+element.bloglink+'">Learn more</a>';
             if(element.gif) gif = '<br><img src="./extensions/'+element.name+'/extension.gif" alt="Sample Image">';
             let contents = '<p>'+Extensions[index].description+'</p>'+moredetails+gif;
             $(checkbox.item(i).parentNode).next().popover({

--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,7 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li>
-          <a href="https://github.com/libvarun/forge-extensions" target="_blank">
+          <a href="https://github.com/autodesk-forge/forge-extensions" target="_blank">
             <img alt="Autodesk Forge" src="/img/GitHub_Logo.png" height="25">
           </a>
         </li>

--- a/routes/oss.js
+++ b/routes/oss.js
@@ -74,6 +74,8 @@ router.get('/buckets', async (req, res, next) => {
 
 // POST /api/forge/oss/buckets - creates a new bucket.
 // Request body must be a valid JSON in the form of { "bucketKey": "<new_bucket_name>" }.
+// This sample will not allow creation of new buckets
+/*
 router.post('/buckets', async (req, res, next) => {
     let payload = new PostBucketsPayload();
     payload.bucketKey = config.credentials.client_id.toLowerCase() + '-' + req.body.bucketKey;
@@ -86,6 +88,7 @@ router.post('/buckets', async (req, res, next) => {
         next(err);
     }
 });
+*/
 
 // POST /api/forge/oss/objects - uploads new object to given bucket.
 // Request body must be structured as 'form-data' dictionary
@@ -97,7 +100,7 @@ router.post('/objects', multer({ dest: 'uploads/' }).single('fileToUpload'), asy
         }
         try {
             // Upload an object to bucket using [ObjectsApi](https://github.com/Autodesk-Forge/forge-api-nodejs-client/blob/master/docs/ObjectsApi.md#uploadObject).
-            if(req.body.bucketKey === "samplemodels"){
+            if(req.body.bucketKey === config.credentials.client_id.toLowerCase() + '-' + "samplemodels"){
                 res.status(500).end();
             } 
             else{


### PR DESCRIPTION
Created missing readme for each extension
Tooltip to point to the readme (which may point to a blog post)
Remove the `create bucket` feature (the endpoint was exposed)